### PR TITLE
implemented Projectile spell

### DIFF
--- a/Assets/Prefabs/projectile1.prefab
+++ b/Assets/Prefabs/projectile1.prefab
@@ -1,0 +1,132 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1399096159753678161
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1399096159753678154}
+  - component: {fileID: 1399096159753678157}
+  - component: {fileID: 1399096159753678156}
+  - component: {fileID: 1399096159753678159}
+  - component: {fileID: 1399096159753678158}
+  - component: {fileID: 1399096159753678155}
+  m_Layer: 0
+  m_Name: projectile1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1399096159753678154
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1399096159753678161}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.13319468, y: 8.162194, z: -1.74823}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &1399096159753678157
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1399096159753678161}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &1399096159753678156
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1399096159753678161}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 0b763b3fed4450a419e4848ced31b416, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!135 &1399096159753678159
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1399096159753678161}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &1399096159753678158
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1399096159753678161}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 66d25d71c15d2c044b09169575345392, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hit:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!54 &1399096159753678155
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1399096159753678161}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0

--- a/Assets/Prefabs/projectile1.prefab.meta
+++ b/Assets/Prefabs/projectile1.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 85004be46777f894f890e8f7577000e0
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/TestAI.unity
+++ b/Assets/Scenes/TestAI.unity
@@ -5432,22 +5432,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 3407136574621682999, guid: a0d883965b4d31d41bf17755e92ab8fe, type: 3}
   m_PrefabInstance: {fileID: 2936960299666216256}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1910140346
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1582513222}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8b01be0e79bcf46488709e8d307d5f19, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  rigidbody: {fileID: 0}
-  collider: {fileID: 0}
-  agent: {fileID: 0}
-  tree: {fileID: 11400000, guid: 4d7ca120f25be5742afd2c2aed2c4795, type: 2}
 --- !u!114 &1910140347
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -5484,7 +5468,7 @@ NavMeshAgent:
   m_BaseOffset: -0.04
   m_WalkableMask: 4294967295
   m_ObstacleAvoidanceType: 4
---- !u!114 &1910140349
+--- !u!114 &1910140354
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -5493,12 +5477,31 @@ MonoBehaviour:
   m_GameObject: {fileID: 1582513222}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 590965104d5333e41bde89e1763342ae, type: 3}
+  m_Script: {fileID: 11500000, guid: bb239e5a2e8bf824caee33af8dcfd9db, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  rigidbody: {fileID: 0}
+  collider: {fileID: 0}
+  agent: {fileID: 0}
+  tree: {fileID: 11400000, guid: 18991da7079be9d4fa31bb6e919211df, type: 2}
+--- !u!114 &1910140355
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1582513222}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 433884dc24ed0d04c90eaa68190b7cd2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   effects:
   - {fileID: 11400000, guid: 5ac1670d20feb394cb0880030b1bf693, type: 2}
-  coolDownInSeconds: 5
+  projectile: {fileID: 1399096159753678161, guid: 85004be46777f894f890e8f7577000e0, type: 3}
+  velocity: 5
+  coolDown: 5
+  target: 0
 --- !u!1001 &1927104978
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7126,6 +7129,18 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 0.755, y: 1.150387, z: 0.65385}
   m_Center: {x: 0, y: 0.5751935, z: 0.00000011920929}
+--- !u!114 &3821831712773831644
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3821831712773831638}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 99334688e54f46b4389142813f3ff467, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &3821831712802960961
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/AI_System/AI_Destinations.cs
+++ b/Assets/Scripts/AI_System/AI_Destinations.cs
@@ -30,7 +30,7 @@ public class AI_Destinations: MonoBehaviour
     }
 
     //data
-    /*
+    
     [SerializeField]private GameObject Ika;
     [SerializeField]private GameObject tree;
 
@@ -38,22 +38,21 @@ public class AI_Destinations: MonoBehaviour
     {
         Ika = GameObject.FindGameObjectWithTag("Player");
     }
-    public GameObject getDest(Dest destination)
+    public static GameObject getGameObjectFromDestination(Dest destination)
     {
         if (destination == Dest.IKA)
         {
-            if(Ika != null)
-            {
-                Debug.Log("giving Ika to node");
-                return Ika;
-            }
+           
+            Debug.Log("giving Ika to node");
+            return GameObject.FindGameObjectWithTag("Player");
+            
         }
-        return tree;
+        return null;
     }
     // Start is called before the first frame update
     void Start()
     {
-        
+        updateDestinations();
     }
 
     // Update is called once per frame
@@ -61,10 +60,12 @@ public class AI_Destinations: MonoBehaviour
     {
         
     }
+    /*
     private void OnDestroy()
     {
         EventManager.Instance.Unsubscribe(EventTypes.Events.LOAD_SCENE, updateDestinations);
         Instance = null;
 
-    }*/
+    }
+    */
 }

--- a/Assets/Scripts/AI_System/BehaviorTree.cs
+++ b/Assets/Scripts/AI_System/BehaviorTree.cs
@@ -11,7 +11,6 @@ public class BehaviorTree : ScriptableObject
 
     public List<Node> nodes = new List<Node>();
     private GameObject thisAI;
-
     public Node.State Update()
     {
         if(rootNode.state == Node.State.RUNNING)
@@ -93,8 +92,8 @@ public class BehaviorTree : ScriptableObject
     }
     public List<Node> GetChildren(Node parent)
     {
-        List<Node> children = new List<Node>()
-            ;
+        List<Node> children = new List<Node>();
+
         DecoratorNode dec = parent as DecoratorNode;
         if (dec && dec.child != null)
         {
@@ -129,4 +128,5 @@ public class BehaviorTree : ScriptableObject
     {
         return thisAI;
     }
+    
 }

--- a/Assets/Scripts/AI_System/GoToNode.cs
+++ b/Assets/Scripts/AI_System/GoToNode.cs
@@ -12,7 +12,7 @@ public class GoToNode : ActionNode
 
     public void Awake()
     {
-        setEnemy();
+        enemy = AI_Destinations.getGameObjectFromDestination(destination);
     }
     protected override void OnStart()
     {
@@ -22,19 +22,7 @@ public class GoToNode : ActionNode
         //enemy = AI_Actions.Instance.getDest(destination);
     }
 
-    public void setEnemy()
-    {
-        //enemy = AI_Actions.Instance.getDest(destination);
-        if(destination == AI_Destinations.Dest.IKA)
-        {
-            Debug.Log("set the enemy");
-            enemy = GameObject.FindGameObjectWithTag("Player");
-        }
-        else if(destination == AI_Destinations.Dest.TREE)
-        {
-            enemy = GameObject.FindGameObjectWithTag("Tree");
-        }
-    }
+   
     protected override void OnStop()
     {
         //EventManager.Instance.Unsubscribe(EventTypes.Events.LOAD_SCENE, setEnemy);

--- a/Assets/Scripts/AI_System/MageBehavior.asset
+++ b/Assets/Scripts/AI_System/MageBehavior.asset
@@ -1,0 +1,81 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-5328242443326668875
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 49df97fdf4223e8419bac7d4cee9ab32, type: 3}
+  m_Name: ProjectileNode
+  m_EditorClassIdentifier: 
+  state: 0
+  started: 0
+  guid: c150bfbdbe9304847bf60bd57feb350f
+  position: {x: -64.93505, y: -55.99998}
+  NodeName: 
+  myTree: {fileID: 11400000}
+  mask:
+    serializedVersion: 2
+    m_Bits: 8
+  target: 0
+  coolDownInSeconds: 5
+--- !u!114 &-63931876484464690
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 002c4931053343a49b7624394504ec96, type: 3}
+  m_Name: RootNode
+  m_EditorClassIdentifier: 
+  state: 0
+  started: 0
+  guid: bf71b873075d0bd47bb35ad73d484129
+  position: {x: -466.8425, y: -55.54501}
+  NodeName: 
+  myTree: {fileID: 11400000}
+  child: {fileID: 8538462142742909319}
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 270d45d981650274ca7d39b317c3c634, type: 3}
+  m_Name: MageBehavior
+  m_EditorClassIdentifier: 
+  rootNode: {fileID: -63931876484464690}
+  treeState: 0
+  nodes:
+  - {fileID: -63931876484464690}
+  - {fileID: 8538462142742909319}
+  - {fileID: -5328242443326668875}
+--- !u!114 &8538462142742909319
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d4850d63ead855e4286e1418d5b14467, type: 3}
+  m_Name: RepeatNode
+  m_EditorClassIdentifier: 
+  state: 0
+  started: 0
+  guid: 298f2e98c5aa1604487b5592869b2bb5
+  position: {x: -277.725, y: -56.000023}
+  NodeName: 
+  myTree: {fileID: 11400000}
+  child: {fileID: -5328242443326668875}

--- a/Assets/Scripts/AI_System/MageBehavior.asset.meta
+++ b/Assets/Scripts/AI_System/MageBehavior.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 18991da7079be9d4fa31bb6e919211df
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/AI_System/MeleeAttack.cs
+++ b/Assets/Scripts/AI_System/MeleeAttack.cs
@@ -8,8 +8,12 @@ public class MeleeAttack : ActionNode
     private Melee attackSpell;
     public LayerMask mask;
 
+    public float coolDownInSeconds;
+    private float nextAttackTime;
+
     public void Awake()
     {
+        nextAttackTime = Time.time;
         myAI = myTree.getAI();
         attackSpell = myAI.GetComponent<Melee>();
         attackSpell.setLayerMask(mask);
@@ -24,7 +28,15 @@ public class MeleeAttack : ActionNode
 
     protected override State OnUpdate()
     {
-        attackSpell.Cast();
-        return Node.State.FAILURE;
+        if (Time.time > nextAttackTime)
+        {
+            attackSpell.Cast();
+            nextAttackTime = Time.time + coolDownInSeconds;
+            return Node.State.SUCCESS;
+        }
+        else
+        {
+            return Node.State.RUNNING;
+        }
     }
 }

--- a/Assets/Scripts/AI_System/OldManMcgee.asset
+++ b/Assets/Scripts/AI_System/OldManMcgee.asset
@@ -18,7 +18,7 @@ MonoBehaviour:
   position: {x: 13.400003, y: -24.30008}
   NodeName: go to Ika
   myTree: {fileID: 11400000}
-  destination: 0
+  destination: 1
 --- !u!114 &11400000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -86,7 +86,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0e564f630f0d5c04dbcac4c9f6ab7e6f, type: 3}
   m_Name: MeleeAttack
@@ -100,6 +100,7 @@ MonoBehaviour:
   mask:
     serializedVersion: 2
     m_Bits: 1032
+  coolDownInSeconds: 5
 --- !u!114 &8621316797458655555
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/AI_System/ProjectileNode.cs
+++ b/Assets/Scripts/AI_System/ProjectileNode.cs
@@ -1,0 +1,59 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.AI;
+
+public class ProjectileNode : ActionNode
+{
+    private GameObject myAI;
+    private Projectile projectileSpell;
+    public LayerMask mask;
+    public AI_Destinations.Dest target;
+    private GameObject enemy;
+
+    public float coolDownInSeconds;
+    private float nextAttackTime;
+
+    public void Awake()
+    {
+        myAI = myTree.getAI();
+        projectileSpell = myAI.GetComponent<Projectile>();
+        projectileSpell.setLayerMask(mask);
+        nextAttackTime = Time.time;
+        enemy = AI_Destinations.getGameObjectFromDestination(target);
+    }
+    protected override void OnStart()
+    {
+    }
+
+    protected override void OnStop()
+    {
+    }
+
+    protected override State OnUpdate()
+    {
+        Vector3 dirFromAIToEnemey = (enemy.transform.position - myAI.transform.position).normalized;
+
+        float dotProd = Vector3.Dot(dirFromAIToEnemey, myAI.transform.forward);
+
+        if (dotProd > 0.95)
+        {
+            // ObjA is looking mostly towards ObjB
+            if (Time.time > nextAttackTime)
+            {
+                projectileSpell.Cast();
+                nextAttackTime = Time.time + coolDownInSeconds;
+                return Node.State.SUCCESS;
+            }
+
+        }
+        else
+        {
+            var targetRotation = Quaternion.LookRotation(enemy.transform.position - myAI.transform.position);
+
+            // Smoothly rotate towards the target point.
+            myAI.transform.rotation = Quaternion.Slerp(myAI.transform.rotation, targetRotation, Time.deltaTime);
+        }
+        return Node.State.RUNNING;
+    }
+}

--- a/Assets/Scripts/AI_System/ProjectileNode.cs.meta
+++ b/Assets/Scripts/AI_System/ProjectileNode.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 49df97fdf4223e8419bac7d4cee9ab32
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Attack System/Melee.cs
+++ b/Assets/Scripts/Attack System/Melee.cs
@@ -7,8 +7,6 @@ public class Melee : Spell
     private bool m_Started;
     private LayerMask layer;
 
-    public float coolDownInSeconds;
-    private float nextAttackTime;
     public void Start()
     {
         m_Started = true;
@@ -24,8 +22,7 @@ public class Melee : Spell
     {
         //find objects hit in a box
         //used transform.forward to place box in front of gameobject
-        if (Time.time > nextAttackTime)
-        {
+        
             Collider[] hits = Physics.OverlapBox(gameObject.transform.position + transform.forward * 3, Vector3.one * 3, Quaternion.identity, layer);
 
             for (int i = 0; i < hits.Length; i++)
@@ -37,11 +34,7 @@ public class Melee : Spell
                     ApplySpellEffect(entity, effects[j]);
                 }
             }
-            nextAttackTime = Time.time + coolDownInSeconds;
             Debug.Log("attacked player");
-
-        }
-        //apply spell effects
     }
 
     //Draw the Box Overlap as a gizmo to show where it currently is testing. Click the Gizmos button to see this

--- a/Assets/Scripts/Attack System/Projectile.cs
+++ b/Assets/Scripts/Attack System/Projectile.cs
@@ -1,0 +1,52 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Projectile : Spell
+{
+    public GameObject projectile;
+    public float velocity = 10f;
+    public float coolDown = 5f;
+    private LayerMask mask;
+    private GameObject enemy;
+    public AI_Destinations.Dest target;
+
+    public override void Cast()
+    {
+       Quaternion angle = Quaternion.LookRotation(enemy.transform.position - transform.position);
+
+        GameObject p = Instantiate(projectile, transform.position + new Vector3(0, 1, 0),
+                                                angle);
+        ProjectileLogic logic = p.GetComponent<ProjectileLogic>();
+
+        logic.hit.AddListener(ApplySpellEffects);
+        logic.setLayerMask(mask);
+        Vector3 direction_and_speed = p.transform.forward * velocity;
+        p.GetComponent<Rigidbody>().AddForce(direction_and_speed, ForceMode.VelocityChange);
+    
+    }
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        enemy = AI_Destinations.getGameObjectFromDestination(target);
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+    private void ApplySpellEffects(GameObject entity)
+    {
+        for (int j = 0; j < effects.Count; j++)
+        {
+            effects[j].Process(entity);
+        }
+    }
+
+    public void setLayerMask(LayerMask mask)
+    {
+        this.mask = mask;
+    }
+}

--- a/Assets/Scripts/Attack System/Projectile.cs.meta
+++ b/Assets/Scripts/Attack System/Projectile.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 433884dc24ed0d04c90eaa68190b7cd2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Attack System/ProjectileLogic.cs
+++ b/Assets/Scripts/Attack System/ProjectileLogic.cs
@@ -1,0 +1,47 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Events;
+
+[RequireComponent(typeof(Rigidbody))]
+[RequireComponent(typeof(SphereCollider))]
+
+
+public class ProjectileLogic : MonoBehaviour
+{
+    // Start is called before the first frame update
+    public UnityEvent<GameObject> hit;
+    private LayerMask mask;
+    void Start()
+    {
+    }
+    private void Awake()
+    {
+        gameObject.GetComponent<SphereCollider>().isTrigger = true;
+        hit = new UnityEvent<GameObject>();
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+    private void OnTriggerEnter(Collider other)
+    {
+        //had to get string name of the layer mask
+        if (((1 << other.gameObject.layer) & mask) != 0)
+        {
+            hit.Invoke(other.gameObject);
+            Destroy(gameObject);
+        }
+        else
+        {
+            Destroy(gameObject);
+        }
+    }
+
+    public void setLayerMask(LayerMask mask)
+    {
+        this.mask = mask;
+    }
+}

--- a/Assets/Scripts/Attack System/ProjectileLogic.cs.meta
+++ b/Assets/Scripts/Attack System/ProjectileLogic.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 66d25d71c15d2c044b09169575345392
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Entities/MageEntity.cs
+++ b/Assets/Scripts/Entities/MageEntity.cs
@@ -4,9 +4,11 @@ using UnityEngine;
 using UnityEngine.AI;
 
 [RequireComponent(typeof(NavMeshAgent))]
-[RequireComponent(typeof(Melee))]
-public class DummyEntity : CombatEntity
+[RequireComponent(typeof(Projectile))]
+
+public class MageEntity : CombatEntity
 {
+
     [HideInInspector]public NavMeshAgent agent;
     public BehaviorTree tree;
     // Start is called before the first frame update

--- a/Assets/Scripts/Entities/MageEntity.cs.meta
+++ b/Assets/Scripts/Entities/MageEntity.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bb239e5a2e8bf824caee33af8dcfd9db
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The projectile Spell has been impleminted and giving an object the MageEntity script will make the projectile class a required component. It must be assigned a behaviour tree, which can be made in the Behaviour tree editor window. Make a projectile node and set it's target to IKA. This causes the NavMesh agent to first turn to face the target, then shoot a projectile. Remember to also set the projectile GameObject in the Projectile script. I provided one labled Projectile1 in the Prefabs folder. Attached to it is a script called Projectile logic which handles itself. I left my test setup in the AITest scene. note that standing on the flower protects Ika from the projectiles becasue they hit the flower's collider first.